### PR TITLE
Analyze safari copy slowness

### DIFF
--- a/src/lib/components/CopyButton.svelte
+++ b/src/lib/components/CopyButton.svelte
@@ -17,7 +17,9 @@
 
 		running = true;
 		try {
-			const scale = 3;
+			// Detect Safari and use lower scale for better performance
+			const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+			const scale = isSafari ? 2 : 3;
 			const { offsetWidth, offsetHeight } = output;
 
 			await navigator.clipboard.write([
@@ -25,6 +27,8 @@
 					'image/png': domtoimage.toBlob(output, {
 						height: offsetHeight * scale,
 						width: offsetWidth * scale,
+						quality: isSafari ? 0.8 : 1.0, // Reduce quality for Safari
+						cacheBust: false, // Disable cache busting for better performance
 						style: {
 							transform: `scale(${scale})`,
 							transformOrigin: 'top left',

--- a/src/lib/renderers/2025/RadioBox.svelte
+++ b/src/lib/renderers/2025/RadioBox.svelte
@@ -53,7 +53,7 @@
 <div
 	class="font-f1 flex w-[320px] flex-col overflow-clip bg-gray-900 [font-variant-ligatures:none]"
 	bind:this={element}
-	style="--team-color: {team.color}; --light-team-color: color-mix(in oklab, var(--team-color), white);"
+	style="--team-color: {team.color}; --light-team-color: color-mix(in oklab, var(--team-color), white); will-change: transform;"
 >
 	<div class="relative z-0 flex flex-col p-3">
 		<div class="flex flex-row items-center justify-end">


### PR DESCRIPTION
Optimize image copy performance on Safari by reducing scale and quality, and adding `will-change`.

The "copy now" feature was slow on Safari due to the `dom-to-image` library's performance with complex DOM structures and high-resolution image generation. This PR addresses these bottlenecks by applying Safari-specific optimizations.

---

[Open in Web](https://www.cursor.com/agents?id=bc-caf6d503-9558-4404-927a-19d91b96800d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-caf6d503-9558-4404-927a-19d91b96800d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)