### PR TITLE
Speed up html to image conversion with snapdom

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@vercel/analytics": "^1.5.0",
 		"@vercel/speed-insights": "^1.2.0",
-		"dom-to-image": "^2.6.0",
+		"@zumer/snapdom": "^1.9.7",
 		"tailwind-merge": "^1.14.0"
 	},
 	"devDependencies": {
@@ -32,7 +32,6 @@
 		"@sveltejs/kit": "^2.22.2",
 		"@sveltejs/vite-plugin-svelte": "^5.1.0",
 		"@tailwindcss/vite": "^4.1.11",
-		"@types/dom-to-image": "^2.6.7",
 		"@typescript-eslint/eslint-plugin": "^6.21.0",
 		"@typescript-eslint/parser": "^6.21.0",
 		"eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       '@vercel/speed-insights':
         specifier: ^1.2.0
         version: 1.2.0(@sveltejs/kit@2.22.2(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.9)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.34.9)(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)))(svelte@5.34.9)
-      dom-to-image:
-        specifier: ^2.6.0
-        version: 2.6.0
+      '@zumer/snapdom':
+        specifier: ^1.9.7
+        version: 1.9.7
       tailwind-merge:
         specifier: ^1.14.0
         version: 1.14.0
@@ -39,9 +39,6 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))
-      '@types/dom-to-image':
-        specifier: ^2.6.7
-        version: 2.6.7
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.21.0
         version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
@@ -686,9 +683,6 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
-  '@types/dom-to-image@2.6.7':
-    resolution: {integrity: sha512-me5VbCv+fcXozblWwG13krNBvuEOm6kA5xoa4RrjDJCNFOZSWR3/QLtOXimBHk1Fisq69Gx3JtOoXtg1N1tijg==}
-
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -847,6 +841,9 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@zumer/snapdom@1.9.7':
+    resolution: {integrity: sha512-tZvEq0e0NYn1gEyPCPZPOVQ5ihSFEGi2ppvpzi0dRL9vruPh8JrpPkcoG4IdqJHnF4y68wU0GZvlsQqEoeMCsg==}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -1028,9 +1025,6 @@ packages:
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
-
-  dom-to-image@2.6.0:
-    resolution: {integrity: sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2483,8 +2477,6 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
-  '@types/dom-to-image@2.6.7': {}
-
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2656,6 +2648,8 @@ snapshots:
       loupe: 3.1.4
       tinyrainbow: 2.0.0
 
+  '@zumer/snapdom@1.9.7': {}
+
   abbrev@3.0.1: {}
 
   acorn-import-attributes@1.9.5(acorn@8.15.0):
@@ -2796,8 +2790,6 @@ snapshots:
   doctrine@3.0.0:
     dependencies:
       esutils: 2.0.3
-
-  dom-to-image@2.6.0: {}
 
   eastasianwidth@0.2.0: {}
 

--- a/src/lib/components/CopyButton.svelte
+++ b/src/lib/components/CopyButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import domtoimage from 'dom-to-image';
+	import { snapdom } from '@zumer/snapdom';
 
 	interface Props {
 		element?: HTMLElement | undefined;
@@ -20,18 +20,17 @@
 			const scale = 3;
 			const { offsetWidth, offsetHeight } = output;
 
+			// Use snapdom.toBlob for much faster HTML to image conversion
+			const blob = await snapdom.toBlob(output, {
+				scale: scale,
+				width: offsetWidth * scale,
+				height: offsetHeight * scale,
+				type: 'png'
+			});
+
 			await navigator.clipboard.write([
 				new ClipboardItem({
-					'image/png': domtoimage.toBlob(output, {
-						height: offsetHeight * scale,
-						width: offsetWidth * scale,
-						style: {
-							transform: `scale(${scale})`,
-							transformOrigin: 'top left',
-							width: `${offsetWidth}px`,
-							height: `${offsetHeight}px`
-						}
-					})
+					'image/png': blob
 				})
 			]);
 


### PR DESCRIPTION
Replace `dom-to-image` with `@zumer/snapdom` to significantly improve HTML to image conversion speed.

---

[Open in Web](https://cursor.com/agents?id=bc-7ac64cf6-84ee-4d12-bd9f-32273ff364d5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7ac64cf6-84ee-4d12-bd9f-32273ff364d5) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)